### PR TITLE
reduce flints from gravel per issue 7

### DIFF
--- a/datapack/data/stonecutter_mill/recipes/stonecut_flint.json
+++ b/datapack/data/stonecutter_mill/recipes/stonecut_flint.json
@@ -5,5 +5,5 @@
         "item": "minecraft:gravel"
     },
     "result": "minecraft:flint",
-    "count": 4
+    "count": 1
 }


### PR DESCRIPTION
- removed .DS_Store
- reduced number of flints from gravel from 4 to 1 per issue 7
